### PR TITLE
docs: fix category typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You will need to have `graphviz` installed to generate the graphs; it uses
     packagetype typename[role-signature] is typename[role-signature] # inheritance
     packagetype typename[role-signature] does typename[role-signature] # roles
 
-    [ Another cateogory ]
+    [ Another category ]
 
 - Supported categories: `Metamodel`, `Domain-specific`, `Basic`, `Composite`, `Exceptions` and `Core`.
 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `cateogory` to `category` in the README example.

Fixes #35

## Test plan
- static validation: `cateogory` appeared 1 time(s) in `README.md` before replacement.
- static validation: `category` is present in `README.md` after patch.
- static validation: `cateogory` is absent from `README.md` after patch.
- Not run: runtime test suite, because this is a README-only typo fix.
